### PR TITLE
update-initramfs for zfs.conf

### DIFF
--- a/install-post.sh
+++ b/install-post.sh
@@ -329,5 +329,8 @@ options zfs l2arc_write_max=524288000
 EOF
 fi
 
+# propagate the setting into the kernel
+update-initramfs -u -k all
+
 ## Script Finish
 echo -e '\033[1;33m Finished....please restart the system \033[0m'


### PR DESCRIPTION
as you could remark with 

`cat /sys/module/zfs/parameters/zfs_arc_min`

`/etc/modprobe.d/zfs.conf` parameter won't take effect unless the kernel is updated

[why isnt the arc max setting honoured on zfs on linux](https://serverfault.com/questions/581669/why-isnt-the-arc-max-setting-honoured-on-zfs-on-linux)

_it also mentioned on proxmox forum_