### PR TITLE
fail2ban proxmox don't load

### DIFF
--- a/install-post.sh
+++ b/install-post.sh
@@ -193,7 +193,7 @@ cat <<EOF > /etc/fail2ban/filter.d/proxmox.conf
 failregex = pvedaemon\[.*authentication failure; rhost=<HOST> user=.* msg=.*
 ignoreregex =
 EOF
-cat <<EOF > /etc/fail2ban/jail.d/proxmox
+cat <<EOF > /etc/fail2ban/jail.d/proxmox.conf
 [proxmox]
 enabled = true
 port = https,http,8006


### PR DESCRIPTION
#### at least with Fail2Ban __v0.9.6__

it is not working if the file is not ending by .conf