### PR TITLE
Fix NoSubscription banner

### DIFF
--- a/install-post.sh
+++ b/install-post.sh
@@ -228,11 +228,13 @@ sysctl -p
 ## Remove subscription banner
 if [ -f "/usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js" ] ; then
   sed -i "s/data.status !== 'Active'/false/g" /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
+  sed -i "s/checked_command: function(orig_cmd) {/checked_command: function() {} || function(orig_cmd) {/g" /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
   # create a daily cron to make sure the banner does not re-appear
   cat <<'EOF' > /etc/cron.daily/proxmox-nosub
 #!/bin/sh
 # eXtremeSHOK.com Remove subscription banner
 sed -i "s/data.status !== 'Active'/false/g" /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
+sed -i "s/checked_command: function(orig_cmd) {/checked_command: function() {} || function(orig_cmd) {/g" /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
 EOF
   chmod 755 /etc/cron.daily/proxmox-nosub
 fi


### PR DESCRIPTION
In Proxmox 6.3-3, the no subscription fix does not work, so fixing it so it works in 6.3+ and older versions as before.